### PR TITLE
refactor: separate block and item registries for better maintainability

### DIFF
--- a/src/main/java/com/example/magicmod/MagicMod.java
+++ b/src/main/java/com/example/magicmod/MagicMod.java
@@ -5,11 +5,8 @@ import com.example.magicmod.item.register.ModItemRegister;
 import com.mojang.logging.LogUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
@@ -21,7 +18,6 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
-import net.minecraftforge.registries.RegistryObject;
 import org.slf4j.Logger;
 
 // The value here should match an entry in the META-INF/mods.toml file

--- a/src/main/java/com/example/magicmod/block/register/ModBlockRegister.java
+++ b/src/main/java/com/example/magicmod/block/register/ModBlockRegister.java
@@ -12,9 +12,6 @@ import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 
-import java.util.Arrays;
-import java.util.Set;
-
 import static com.example.magicmod.MagicMod.MODID;
 
 public class ModBlockRegister {

--- a/src/main/java/com/example/magicmod/item/register/ModItemRegister.java
+++ b/src/main/java/com/example/magicmod/item/register/ModItemRegister.java
@@ -1,8 +1,6 @@
 package com.example.magicmod.item.register;
 
 import com.example.magicmod.MagicMod;
-import com.example.magicmod.block.register.ModBlockRegister;
-import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraftforge.eventbus.api.bus.BusGroup;
 import net.minecraftforge.registries.DeferredRegister;


### PR DESCRIPTION
Seperate item and block registries into two separate class `ModBlockRegister.java` and `ModItemRegister.java`.